### PR TITLE
Remove deprecated sdmmc mount API call for sdspi for ESP-IDF 4.2

### DIFF
--- a/src/services/sd_card.cpp
+++ b/src/services/sd_card.cpp
@@ -2,6 +2,7 @@
 #include "sd_card.hpp"
 
 #include "esp_vfs_fat.h"
+#include "esp_idf_version.h"
 #include "driver/sdmmc_host.h"
 #include "driver/sdspi_host.h"
 #include "sdmmc_cmd.h"
@@ -16,15 +17,19 @@ SDCard::setup()
   static const gpio_num_t PIN_NUM_CLK  = GPIO_NUM_14;
   static const gpio_num_t PIN_NUM_CS   = GPIO_NUM_15;
 
+  esp_err_t ret;
   sdmmc_host_t        host        = SDSPI_HOST_DEFAULT();
-  sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
 
-  host.flags = SDMMC_HOST_FLAG_SPI;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0)
+
+  sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
 
   slot_config.gpio_miso = PIN_NUM_MISO;
   slot_config.gpio_mosi = PIN_NUM_MOSI;
   slot_config.gpio_sck  = PIN_NUM_CLK;
   slot_config.gpio_cs   = PIN_NUM_CS;
+
+#endif
 
   esp_vfs_fat_sdmmc_mount_config_t mount_config = {
     .format_if_mount_failed = false,
@@ -33,7 +38,7 @@ SDCard::setup()
   };
 
   sdmmc_card_t* card;
-  esp_err_t ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+  ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
 
   if (ret != ESP_OK) {
     if (ret == ESP_FAIL) {

--- a/src/services/sd_card.cpp
+++ b/src/services/sd_card.cpp
@@ -18,7 +18,14 @@ SDCard::setup()
   static const gpio_num_t PIN_NUM_CS   = GPIO_NUM_15;
 
   esp_err_t ret;
-  sdmmc_host_t        host        = SDSPI_HOST_DEFAULT();
+  sdmmc_host_t host = SDSPI_HOST_DEFAULT();
+  esp_vfs_fat_sdmmc_mount_config_t mount_config = {
+    .format_if_mount_failed = false,
+    .max_files = 5,
+    .allocation_unit_size = 16 * 1024
+  };
+
+  sdmmc_card_t* card;
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 2, 0)
 
@@ -29,16 +36,9 @@ SDCard::setup()
   slot_config.gpio_sck  = PIN_NUM_CLK;
   slot_config.gpio_cs   = PIN_NUM_CS;
 
-#endif
-
-  esp_vfs_fat_sdmmc_mount_config_t mount_config = {
-    .format_if_mount_failed = false,
-    .max_files = 5,
-    .allocation_unit_size = 16 * 1024
-  };
-
-  sdmmc_card_t* card;
   ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+
+#endif
 
   if (ret != ESP_OK) {
     if (ret == ESP_FAIL) {

--- a/src/services/sd_card.cpp
+++ b/src/services/sd_card.cpp
@@ -38,6 +38,31 @@ SDCard::setup()
 
   ret = esp_vfs_fat_sdmmc_mount("/sdcard", &host, &slot_config, &mount_config, &card);
 
+#else
+
+  sdspi_device_config_t slot_config = SDSPI_DEVICE_CONFIG_DEFAULT();
+
+  slot_config.gpio_cs = PIN_NUM_CS;
+
+  spi_bus_config_t bus_cfg = {
+    .mosi_io_num     = PIN_NUM_MOSI,
+    .miso_io_num     = PIN_NUM_MISO,
+    .sclk_io_num     = PIN_NUM_CLK,
+    .quadwp_io_num   = GPIO_NUM_NC,
+    .quadhd_io_num   = GPIO_NUM_NC,
+    .max_transfer_sz = 0, // 0: Default size 4094
+    .flags           = SPICOMMON_BUSFLAG_SLAVE,
+    .intr_flags      = 0,
+  };
+
+  ret = spi_bus_initialize(HSPI_HOST, &bus_cfg, host.slot);
+  if (ret != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to initialize SPI bus (%s).", esp_err_to_name(ret));
+      return false;
+  }
+
+  ret = esp_vfs_fat_sdspi_mount("/sdcard", &host, &slot_config, &mount_config, &card);
+
 #endif
 
   if (ret != ESP_OK) {


### PR DESCRIPTION
## Description

Removed deprecated API `esp_vfs_fat_sdmmc_mount` and replaced it with `esp_vfs_fat_sdspi_mount` if esp-idf version is 4.2 or later.

https://docs.espressif.com/projects/esp-idf/en/v4.2/esp32/api-reference/storage/fatfs.html#_CPPv423esp_vfs_fat_sdmmc_mountPKcPK12sdmmc_host_tPKvPK26esp_vfs_fat_mount_config_tPP12sdmmc_card_t

![image](https://user-images.githubusercontent.com/2971112/109677200-c68b0600-7bbc-11eb-989d-632ad4815160.png)
